### PR TITLE
Update JSON datasource references to grafana-simple-json-datasource

### DIFF
--- a/docs/karavi-observability/README.md
+++ b/docs/karavi-observability/README.md
@@ -88,7 +88,7 @@ Grafana must be configured with the following data sources/plugins:
 | Prometheus data source | [Prometheus data source](https://grafana.com/docs/grafana/latest/features/datasources/prometheus/)   |
 | Data Table plugin      | [Data Table plugin](https://grafana.com/grafana/plugins/briangann-datatable-panel/installation) |
 | Pie Chart plugin       | [Pie Chart plugin](https://grafana.com/grafana/plugins/grafana-piechart-panel)                 |
-| JSON data source       | [JSON data source](https://grafana.com/grafana/plugins/simpod-json-datasource)                 |
+| JSON data source       | [JSON data source](https://grafana.com/grafana/plugins/grafana-simple-json-datasource)                 |
 
 Settings for the Grafana Prometheus data source:
 


### PR DESCRIPTION
# Description

This PR updates documentation to support the grafana-simple-json-datasource instead of simpod-json-datasource.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #11      |

# Checklist:

- [x] I have performed a self-review of my own changes.
