### PR TITLE
Update the otel port reference

### DIFF
--- a/docs/karavi-observability/README.md
+++ b/docs/karavi-observability/README.md
@@ -81,7 +81,7 @@ scrape_configs:
       scrape_interval: 5s
       scheme: https
       static_configs:
-        - targets: ['otel-collector:443']
+        - targets: ['otel-collector:8443']
       tls_config:
         insecure_skip_verify: true
 ```


### PR DESCRIPTION
# Description

With updates for PR https://github.com/dell/karavi-topology/pull/85 merged to main, we need to update the documentation to reference the correct default port for the OTEL service.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|     https://github.com/dell/helm-charts/issues/61   |

# Checklist:

- [x] I have performed a self-review of my own changes.
